### PR TITLE
Update packages and Fix Trivy Issues (AST-100158)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/Checkmarx/containers-resolver
 go 1.24.1
 
 require (
-	github.com/Checkmarx/containers-images-extractor v1.0.8
-	github.com/Checkmarx/containers-syft-packages-extractor v1.0.11
+	github.com/Checkmarx/containers-images-extractor v1.0.9
+	github.com/Checkmarx/containers-syft-packages-extractor v1.0.12
 	github.com/Checkmarx/containers-types v1.0.3
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -61,10 +61,10 @@ github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Checkmarx/containers-images-extractor v1.0.8 h1:X9EYkQKVjhNWcm0VCEFEF4/3O2wXM2QQtSTv5bDxm/I=
-github.com/Checkmarx/containers-images-extractor v1.0.8/go.mod h1:ZtOqhzlErPr2QL9xGjMmxwGvzXUwi+G5BBeOfdY62Ug=
-github.com/Checkmarx/containers-syft-packages-extractor v1.0.11 h1:mXQMz9a68DiP2Pwi4Dwj+ysPGHtGCOdouPSeA9u/Wi0=
-github.com/Checkmarx/containers-syft-packages-extractor v1.0.11/go.mod h1:F9FFBVNmogF0wR9SVI0wRU9dZ9Ux3IZtZl3T24sQ/8E=
+github.com/Checkmarx/containers-images-extractor v1.0.9 h1:+Qe5yWiI43icWg2HDg7C4Xsp5qb5iaryQXUFKvwVDq4=
+github.com/Checkmarx/containers-images-extractor v1.0.9/go.mod h1:KqOq3DUekL9VbklOVgTdZJC/+KLOYdfEoCSY/SWHdxU=
+github.com/Checkmarx/containers-syft-packages-extractor v1.0.12 h1:BgLMkqu0hfoVRoc9/h6Trf6qXoVnAYgOH3Oar78PWPg=
+github.com/Checkmarx/containers-syft-packages-extractor v1.0.12/go.mod h1:EFeB4//lO4KMVj9+eMg6z5jnO9F1e1T4jUoIcx0/19M=
 github.com/Checkmarx/containers-types v1.0.3 h1:srk+RQnyPXyFKmVHA6P9SQZAtjczyndZ1aa0CWF/6/0=
 github.com/Checkmarx/containers-types v1.0.3/go.mod h1:F13rfevriqYHR+0ahk3W9H8uLK0Msbts012f1pIxJb0=
 github.com/CycloneDX/cyclonedx-go v0.9.2 h1:688QHn2X/5nRezKe2ueIVCt+NRqf7fl3AVQk+vaFcIo=


### PR DESCRIPTION
…9 and containers-syft-packages-extractor to v1.0.12