### PR TITLE
Update to use AnalyzeImagesWithPlatform with linux/amd64 default platform (AST-104302)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/Checkmarx/containers-images-extractor v1.0.9
-	github.com/Checkmarx/containers-syft-packages-extractor v1.0.12
+	github.com/Checkmarx/containers-syft-packages-extractor v1.0.13
 	github.com/Checkmarx/containers-types v1.0.3
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Checkmarx/containers-images-extractor v1.0.9 h1:+Qe5yWiI43icWg2HDg7C4Xsp5qb5iaryQXUFKvwVDq4=
 github.com/Checkmarx/containers-images-extractor v1.0.9/go.mod h1:KqOq3DUekL9VbklOVgTdZJC/+KLOYdfEoCSY/SWHdxU=
-github.com/Checkmarx/containers-syft-packages-extractor v1.0.12 h1:BgLMkqu0hfoVRoc9/h6Trf6qXoVnAYgOH3Oar78PWPg=
-github.com/Checkmarx/containers-syft-packages-extractor v1.0.12/go.mod h1:EFeB4//lO4KMVj9+eMg6z5jnO9F1e1T4jUoIcx0/19M=
+github.com/Checkmarx/containers-syft-packages-extractor v1.0.13 h1:9ah0rruMGgRiug/bD/JJDSrDqEqS7sKGVdc5sqbkwk8=
+github.com/Checkmarx/containers-syft-packages-extractor v1.0.13/go.mod h1:EFeB4//lO4KMVj9+eMg6z5jnO9F1e1T4jUoIcx0/19M=
 github.com/Checkmarx/containers-types v1.0.3 h1:srk+RQnyPXyFKmVHA6P9SQZAtjczyndZ1aa0CWF/6/0=
 github.com/Checkmarx/containers-types v1.0.3/go.mod h1:F13rfevriqYHR+0ahk3W9H8uLK0Msbts012f1pIxJb0=
 github.com/CycloneDX/cyclonedx-go v0.9.2 h1:688QHn2X/5nRezKe2ueIVCt+NRqf7fl3AVQk+vaFcIo=

--- a/pkg/containerResolver/containerScanner.go
+++ b/pkg/containerResolver/containerScanner.go
@@ -56,7 +56,7 @@ func (cr *ContainersResolver) Resolve(scanPath string, resolutionFolderPath stri
 	}
 
 	//4. get images resolution
-	resolutionResult, err := cr.AnalyzeImages(imagesToAnalyze)
+	resolutionResult, err := cr.AnalyzeImagesWithPlatform(imagesToAnalyze, "linux/amd64")
 	if err != nil {
 		log.Err(err).Msg("Could not analyze images.")
 		return err


### PR DESCRIPTION
Updated the containers-resolver to use AnalyzeImagesWithPlatform instead of AnalyzeImages with "linux/amd64" as the default platform.

Changes:
- Removed platform parameter from Resolve method
- Hard-coded platform to "linux/amd64" 
- Updated to use AnalyzeImagesWithPlatform
- Updated tests accordingly
- Updated to use v1.0.13 of containers-syft-packages-extractor

All tests pass and code builds successfully.