### PR TITLE
Check for bugs

### DIFF
--- a/pkg/containerResolver/containerScanner.go
+++ b/pkg/containerResolver/containerScanner.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/Checkmarx/containers-images-extractor/pkg/imagesExtractor"
 	"github.com/Checkmarx/containers-syft-packages-extractor/pkg/syftPackagesExtractor"
@@ -33,7 +34,7 @@ func (cr *ContainersResolver) Resolve(scanPath string, resolutionFolderPath stri
 	} else {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
-	log.Debug().Msgf("Resolve func parameters: scanPath=%s, resolutionFolderPath=%s, images=%s, isDebug=%t", scanPath, resolutionFolderPath, images, isDebug)
+	log.Debug().Msgf("Resolve func parameters: scanPath=%s, resolutionFolderPath=%s, images=%s, isDebug=%t", scanPath, resolutionFolderPath, strings.Join(images, ","), isDebug)
 
 	// 0. validate input and create .checkmarx folder
 	checkmarxPath, err := validate(resolutionFolderPath)
@@ -72,7 +73,7 @@ func (cr *ContainersResolver) Resolve(scanPath string, resolutionFolderPath stri
 	}
 
 	//5. cleanup files generated folder
-	err = cleanup(resolutionFolderPath, outputPath, checkmarxPath)
+	err = cleanup(scanPath, outputPath, checkmarxPath)
 	if err != nil {
 		log.Err(err).Msg("Could not cleanup resources.")
 		return err


### PR DESCRIPTION
Fix cleanup logic to prevent scan directory deletion and correct images slice logging.

The cleanup function was comparing against `resolutionFolderPath` instead of `scanPath`, which could lead to the accidental deletion of the scan directory. Additionally, the `images` slice was not being logged correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-c66e1db1-3c99-4d09-9384-60c323436a04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c66e1db1-3c99-4d09-9384-60c323436a04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

